### PR TITLE
feat: allow type imports in tree-shakable/import-star

### DIFF
--- a/src/rules/import-star.test.ts
+++ b/src/rules/import-star.test.ts
@@ -121,6 +121,20 @@ import * as t from 'foo';
 type K = keyof typeof t[Foo];
 `,
       },
+      {
+        name: "TypeScript's type should not affect tree shaking",
+        code: `
+import * as t from 'foo';
+type K = keyof t.SomeType;
+`,
+      },
+      {
+        name: "TypeScript's type should not affect tree shaking",
+        code: `
+import type * as t from 'foo';
+type K = keyof t.SomeType["member"];
+`,
+      },
     ],
     invalid: [
       {

--- a/src/rules/import-star.ts
+++ b/src/rules/import-star.ts
@@ -90,6 +90,10 @@ function isTreeShakingSafeReference(identifier: TSESTree.Identifier): boolean {
       }
       return false;
     }
+    case TSESTree.AST_NODE_TYPES.TSQualifiedName: {
+      // TypeScript's type
+      return true;
+    }
     case TSESTree.AST_NODE_TYPES.TSTypeQuery: {
       // 'typeof t' in TypeScript's type context
       return true;


### PR DESCRIPTION
Updated the eslint rule to support type imports.


Codes that are now valid (previously not valid):

```ts
import * as t from 'io-ts';

const X = t.number;

type X = t.TypeOf<typeof X>;
//       ^
```

```ts
import type * as React from 'react';

export const FC = () => {
  const handleMouseEvent = React.useCallback((e: React.MouseEvent<HTMLElement>) => {
    //                                           ^
  }, []);

  ...
}
```

If this fix is ​​incomplete, please let me know!
