### PR TITLE
feat: support JSXMemberExpression

### DIFF
--- a/src/rules/import-star.test.ts
+++ b/src/rules/import-star.test.ts
@@ -8,6 +8,10 @@ const tester = new TSESLint.RuleTester({
   parserOptions: {
     ecmaVersion: 2020,
     sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
+    jsxPragma: null, // for @typescript/eslint-parser
   },
 });
 
@@ -24,6 +28,16 @@ console.log(t.foo);
         code: `
 import * as t from 'foobar'
 const a = t["foo"];
+`,
+      },
+      {
+        code: `
+import * as React from 'react';
+const FC = () => (
+  <div>
+    <React.Fragment>{"aaa"}</React.Fragment>
+  </div>
+);
 `,
       },
     ],

--- a/src/rules/import-star.ts
+++ b/src/rules/import-star.ts
@@ -56,7 +56,8 @@ function checkModuleNamespaceUsage(
   for (const ref of variable.references) {
     const referencedIdentifier = ref.identifier;
     if (
-      referencedIdentifier.type !== TSESTree.AST_NODE_TYPES.Identifier ||
+      (referencedIdentifier.type !== TSESTree.AST_NODE_TYPES.Identifier &&
+        referencedIdentifier.type !== TSESTree.AST_NODE_TYPES.JSXIdentifier) ||
       !isTreeShakingSafeReference(referencedIdentifier)
     ) {
       context.report({
@@ -70,7 +71,9 @@ function checkModuleNamespaceUsage(
   }
 }
 
-function isTreeShakingSafeReference(identifier: TSESTree.Identifier): boolean {
+function isTreeShakingSafeReference(
+  identifier: TSESTree.Identifier | TSESTree.JSXIdentifier,
+): boolean {
   // Only allow `id.foo` or `id["foo"]` references.
   const parent = identifier.parent;
   if (parent === undefined) {
@@ -90,6 +93,12 @@ function isTreeShakingSafeReference(identifier: TSESTree.Identifier): boolean {
       }
       return false;
     }
+
+    case TSESTree.AST_NODE_TYPES.JSXMemberExpression: {
+      // JSX Elements
+      return true;
+    }
+
     case TSESTree.AST_NODE_TYPES.TSQualifiedName: {
       // TypeScript's type
       return true;


### PR DESCRIPTION
I updated the eslint rule to support JSXMemberExpression.


Codes that are now valid (previously not valid):

```ts
import * as React from 'react';

const FC = () => (
  <div>
    {xs.map(x => <React.Fragment key={x.id}>{x.name}</React.Fragment>)}
  </div>
```
